### PR TITLE
feat: backport module hash query

### DIFF
--- a/server/module_hash.go
+++ b/server/module_hash.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+	"github.com/cosmos/cosmos-sdk/store/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/version"
+)
+
+// ModuleHashByHeightQuery retrieves the module hashes at a given height.
+func ModuleHashByHeightQuery(appCreator servertypes.AppCreator) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "module-hash-by-height [height]",
+		Short:   "Get module hashes at a given height",
+		Long:    "Get module hashes at a given height. This command is useful for debugging and verifying the state of the application at a given height. Daemon should not be running when calling this command.",
+		Example: fmt.Sprintf("%s module-hash-by-height 16841115", version.AppName),
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			heightToRetrieveString := args[0]
+
+			serverCtx := GetServerContextFromCmd(cmd)
+
+			height, err := strconv.ParseInt(heightToRetrieveString, 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid height: %w", err)
+			}
+
+			commitInfoForHeight, err := getModuleHashesAtHeight(serverCtx, appCreator, height)
+			if err != nil {
+				return err
+			}
+
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			return clientCtx.PrintProto(commitInfoForHeight)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func getModuleHashesAtHeight(svrCtx *Context, appCreator servertypes.AppCreator, height int64) (*storetypes.CommitInfo, error) {
+	home := svrCtx.Config.RootDir
+	db, err := openDB(home)
+	if err != nil {
+		return nil, fmt.Errorf("error opening DB, make sure daemon is not running when calling this query: %w", err)
+	}
+	app := appCreator(svrCtx.Logger, db, nil, svrCtx.Viper)
+	rms, ok := app.CommitMultiStore().(*rootmulti.Store)
+	if !ok {
+		return nil, fmt.Errorf("expected rootmulti.Store, got %T", app.CommitMultiStore())
+	}
+
+	commitInfoForHeight, err := rms.GetCommitInfo(height)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new slice of StoreInfos for storing the modified hashes.
+	storeInfos := make([]types.StoreInfo, len(commitInfoForHeight.StoreInfos))
+
+	for i, storeInfo := range commitInfoForHeight.StoreInfos {
+		// Convert the hash to a hexadecimal string.
+		hash := strings.ToUpper(hex.EncodeToString(storeInfo.CommitId.Hash))
+
+		// Create a new StoreInfo with the modified hash.
+		storeInfos[i] = types.StoreInfo{
+			Name: storeInfo.Name,
+			CommitId: types.CommitID{
+				Version: storeInfo.CommitId.Version,
+				Hash:    []byte(hash),
+			},
+		}
+	}
+
+	// Sort the storeInfos slice based on the module name.
+	sort.Slice(storeInfos, func(i, j int) bool {
+		return storeInfos[i].Name < storeInfos[j].Name
+	})
+
+	// Create a new CommitInfo with the modified StoreInfos.
+	commitInfoForHeight = &types.CommitInfo{
+		Version:    commitInfoForHeight.Version,
+		StoreInfos: storeInfos,
+	}
+
+	return commitInfoForHeight, nil
+}

--- a/server/module_hash.go
+++ b/server/module_hash.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
-	"github.com/cosmos/cosmos-sdk/store/types"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/version"
 )
@@ -69,16 +68,16 @@ func getModuleHashesAtHeight(svrCtx *Context, appCreator servertypes.AppCreator,
 	}
 
 	// Create a new slice of StoreInfos for storing the modified hashes.
-	storeInfos := make([]types.StoreInfo, len(commitInfoForHeight.StoreInfos))
+	storeInfos := make([]storetypes.StoreInfo, len(commitInfoForHeight.StoreInfos))
 
 	for i, storeInfo := range commitInfoForHeight.StoreInfos {
 		// Convert the hash to a hexadecimal string.
 		hash := strings.ToUpper(hex.EncodeToString(storeInfo.CommitId.Hash))
 
 		// Create a new StoreInfo with the modified hash.
-		storeInfos[i] = types.StoreInfo{
+		storeInfos[i] = storetypes.StoreInfo{
 			Name: storeInfo.Name,
-			CommitId: types.CommitID{
+			CommitId: storetypes.CommitID{
 				Version: storeInfo.CommitId.Version,
 				Hash:    []byte(hash),
 			},
@@ -91,7 +90,7 @@ func getModuleHashesAtHeight(svrCtx *Context, appCreator servertypes.AppCreator,
 	})
 
 	// Create a new CommitInfo with the modified StoreInfos.
-	commitInfoForHeight = &types.CommitInfo{
+	commitInfoForHeight = &storetypes.CommitInfo{
 		Version:    commitInfoForHeight.Version,
 		StoreInfos: storeInfos,
 	}

--- a/server/util.go
+++ b/server/util.go
@@ -284,6 +284,7 @@ func AddCommands(rootCmd *cobra.Command, defaultNodeHome string, appCreator type
 		ExportCmd(appExport, defaultNodeHome),
 		version.NewVersionCommand(),
 		NewRollbackCmd(appCreator, defaultNodeHome),
+		ModuleHashByHeightQuery(appCreator),
 	)
 }
 

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -156,6 +156,13 @@ func (rs *Store) GetCommitKVStore(key types.StoreKey) types.CommitKVStore {
 	return rs.stores[key]
 }
 
+// GetCommitInfo attempts to retrieve CommitInfo for a given version/height. It
+// will return an error if no CommitInfo exists, we fail to unmarshal the record
+// or if we cannot retrieve the object from the DB.
+func (rs *Store) GetCommitInfo(ver int64) (*types.CommitInfo, error) {
+	return getCommitInfo(rs.db, ver)
+}
+
 // GetStores returns mounted stores
 func (rs *Store) GetStores() map[types.StoreKey]types.CommitKVStore {
 	return rs.stores


### PR DESCRIPTION
# Description

Cherrypicking: https://github.com/cosmos/cosmos-sdk/pull/20779 


Targeting v0.45.x-send-restrictions as took that as base, but will change to a better target

**Diffs:**
1. Timestamp not included in the commitinfo as its not part of the `CommitInfo` struct in sdk 45.  https://github.com/cosmos/cosmos-sdk/blob/61dd9e33854f8eb7eaf1ef0a907e005996117bd7/server/module_hash.go#L97